### PR TITLE
Fix cache clearing and re-enable TADB

### DIFF
--- a/hooks/build
+++ b/hooks/build
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Custom build hook to pass in arguments
 set -x
-docker build --build-arg GIT_BRANCH=$SOURCE_BRANCH --build-arg COMMIT_HASH=$SOURCE_COMMIT -f $DOCKERFILE_PATH -t $IMAGE_NAME .
+docker build --build-arg GIT_BRANCH=$SOURCE_BRANCH --build-arg COMMIT_HASH=$SOURCE_COMMIT -t $IMAGE_NAME .

--- a/lidarrmetadata/api.py
+++ b/lidarrmetadata/api.py
@@ -64,8 +64,8 @@ async def get_overview(links, mbid=None):
         elif wikipedia_link:
             overview, expiry = await overview_providers[0].get_artist_overview(wikipedia_link['target'])
 
-        # if len(overview_providers) > 1 and mbid and not overview:
-        #     overview, expiry = await overview_providers[1].get_artist_overview(mbid)
+        if len(overview_providers) > 1 and mbid and not overview:
+            overview, expiry = await overview_providers[1].get_artist_overview(mbid)
 
     return overview, expiry
 
@@ -142,15 +142,15 @@ async def get_artist_info_multi(mbids):
             artist['data']['images'] = images
             artist['expiry'] = min(artist['expiry'], expiry)
 
-        # if len(artist_art_providers) > 1:
-        #     image_types = {'Banner', 'Fanart', 'Logo', 'Poster'}
-        #     artists_without_images = [x for x in artists if not x['data']['images'] or not image_types.issubset({i['CoverType'] for i in x['data']['images']})]
-        #     results = await asyncio.gather(*[artist_art_providers[1].get_artist_images(x['data']['id']) for x in artists_without_images])
+        if len(artist_art_providers) > 1:
+            image_types = {'Banner', 'Fanart', 'Logo', 'Poster'}
+            artists_without_images = [x for x in artists if not x['data']['images'] or not image_types.issubset({i['CoverType'] for i in x['data']['images']})]
+            results = await asyncio.gather(*[artist_art_providers[1].get_artist_images(x['data']['id']) for x in artists_without_images])
 
-        #     for i, artist in enumerate(artists_without_images):
-        #         images, expiry = results[i]
-        #         artist['data']['images'] = combine_images(artist['data']['images'], images)
-        #         artist['expiry'] = min(artist['expiry'], expiry)
+            for i, artist in enumerate(artists_without_images):
+                images, expiry = results[i]
+                artist['data']['images'] = combine_images(artist['data']['images'], images)
+                artist['expiry'] = min(artist['expiry'], expiry)
     else:
         for artist in artists:
             artist['images'] = []

--- a/lidarrmetadata/sql/updated_artists.sql
+++ b/lidarrmetadata/sql/updated_artists.sql
@@ -13,6 +13,16 @@ SELECT DISTINCT artist.gid
  WHERE artist_credit_name.position = 0
    AND release_group.last_updated > $1
 
+       UNION
+
+  -- artist release updated (release group status is calculated from releases and returned in artist query)
+SELECT DISTINCT artist.gid
+  FROM artist
+         JOIN artist_credit_name ON artist_credit_name.artist = artist.id
+         JOIN release_group ON release_group.artist_credit = artist_credit_name.artist_credit
+         JOIN release ON release.release_group = release_group.id
+ WHERE artist_credit_name.position = 0
+   AND release.last_updated > $1
 
        UNION
        


### PR DESCRIPTION
Make sure that artist cache is cleared if a release is updated (so we capture the release-group status updates which are reported in the artist endpoint)

Reenable TADB for images/overviews.