### PR TITLE
Add endpoint to cache spotify -> musicbrainz mapping

### DIFF
--- a/lidarrmetadata/config.py
+++ b/lidarrmetadata/config.py
@@ -347,6 +347,13 @@ class DefaultConfig(six.with_metaclass(ConfigMeta, ConfigBase)):
             'port': POSTGRES_CACHE_PORT,
             'db_table': 'album',
             'timeout': 0,
+        },
+        'spotify': {
+            'cache': 'lidarrmetadata.cache.PostgresCache',
+            'endpoint': POSTGRES_CACHE_HOST,
+            'port': POSTGRES_CACHE_PORT,
+            'db_table': 'spotify',
+            'timeout': 0,
         }
     }
     
@@ -380,6 +387,12 @@ class DefaultConfig(six.with_metaclass(ConfigMeta, ConfigBase)):
 
         },
         'album': {
+            'cache': 'lidarrmetadata.cache.NullCache',
+            'serializer': {
+                'class': 'lidarrmetadata.cache.ExpirySerializer'
+            }
+        },
+        'spotify': {
             'cache': 'lidarrmetadata.cache.NullCache',
             'serializer': {
                 'class': 'lidarrmetadata.cache.ExpirySerializer'
@@ -441,7 +454,8 @@ class DefaultConfig(six.with_metaclass(ConfigMeta, ConfigBase)):
         'FANARTTVPROVIDER': ([FANART_KEY], {}),
         'WIKIPEDIAPROVIDER': ([], {}),
         'THEAUDIODBPROVIDER': ([TADB_KEY], {}),
-        'SPOTIFYAUTHPROVIDER': ([], {'CLIENT_ID': SPOTIFY_ID, 'CLIENT_SECRET': SPOTIFY_SECRET, 'REDIRECT_URI': SPOTIFY_REDIRECT_URL})
+        'SPOTIFYAUTHPROVIDER': ([], {'CLIENT_ID': SPOTIFY_ID, 'CLIENT_SECRET': SPOTIFY_SECRET, 'REDIRECT_URI': SPOTIFY_REDIRECT_URL}),
+        'SPOTIFYPROVIDER': ([], {'CLIENT_ID': SPOTIFY_ID, 'CLIENT_SECRET': SPOTIFY_SECRET})
     }
 
     # Connection info for sentry. Defaults to None, in which case Sentry won't be used

--- a/lidarrmetadata/sql/all_spotify_maps.sql
+++ b/lidarrmetadata/sql/all_spotify_maps.sql
@@ -1,0 +1,20 @@
+WITH maps AS (
+
+SELECT artist.gid as mbid, substring(url.url from 33) as spotifyid
+FROM artist
+JOIN l_artist_url ON l_artist_url.entity0 = artist.id
+JOIN url ON l_artist_url.entity1 = url.id
+WHERE url.url like 'https://open.spotify.com/artist/%'
+
+UNION
+
+SELECT release_group.gid as mbid, substring(url.url from 32) as spotifyid
+FROM release_group
+JOIN l_release_group_url ON l_release_group_url.entity0 = release_group.id
+JOIN url ON l_release_group_url.entity1 = url.id
+WHERE url.url LIKE 'https://open.spotify.com/album/%'
+
+)
+
+SELECT DISTINCT ON (spotifyid) spotifyid, mbid
+FROM maps

--- a/lidarrmetadata/sql/artist_id_from_spotify_id.sql
+++ b/lidarrmetadata/sql/artist_id_from_spotify_id.sql
@@ -1,0 +1,5 @@
+SELECT artist.gid
+FROM artist
+JOIN l_artist_url ON l_artist_url.entity0 = artist.id
+JOIN url ON l_artist_url.entity1 = url.id
+WHERE url.url = 'https://open.spotify.com/artist/' || $1

--- a/lidarrmetadata/sql/release_group_id_from_spotify_id.sql
+++ b/lidarrmetadata/sql/release_group_id_from_spotify_id.sql
@@ -1,0 +1,5 @@
+SELECT release_group.gid
+FROM release_group
+JOIN l_release_group_url ON l_release_group_url.entity0 = release_group.id
+JOIN url ON l_release_group_url.entity1 = url.id
+WHERE url.url = 'https://open.spotify.com/album/' || $1

--- a/lidarrmetadata/util.py
+++ b/lidarrmetadata/util.py
@@ -35,6 +35,7 @@ TADB_CACHE = caches.get('tadb')
 WIKI_CACHE = caches.get('wikipedia')
 ARTIST_CACHE = caches.get('artist')
 ALBUM_CACHE = caches.get('album')
+SPOTIFY_CACHE = caches.get('spotify')
 
 def first_key_item(dictionary, key, default=None):
     """

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'pytz',
         'python-dateutil',
         'sentry-sdk[flask]',
+        'spotipy',
         'redis',
         'requests',
         'urllib3<1.25',


### PR DESCRIPTION
If a match is found it's permanently cached.  If not found, the 404 is cached for 30 days.