### PR TITLE
Fix root access being requested when not required

### DIFF
--- a/admin/lib/common.inc.bash
+++ b/admin/lib/common.inc.bash
@@ -21,12 +21,12 @@ then
       DOCKER_CMD='docker'
       ;;
     linux*)
-      if groups | grep -Eqw 'sudo|wheel'
-      then
-        DOCKER_CMD='sudo docker'
-      elif groups | grep -Eqw 'docker|root'
+      if groups | grep -Eqw 'docker|root'
       then
         DOCKER_CMD='docker'
+      elif groups | grep -Eqw 'sudo|wheel'
+      then
+        DOCKER_CMD='sudo docker'
       else
         echo >&2 "$SCRIPT_NAME: cannot set docker command: please either"
         echo >&2 "  * add the user '$USER' to the group 'sudo' or 'wheel'"
@@ -49,12 +49,12 @@ then
       DOCKER_COMPOSE_CMD='docker-compose'
       ;;
     linux*)
-      if groups | grep -Eqw 'sudo|wheel'
-      then
-        DOCKER_COMPOSE_CMD='sudo docker-compose'
-      elif groups | grep -Eqw 'docker-compose|root'
+      if groups | grep -Eqw 'docker|root'
       then
         DOCKER_COMPOSE_CMD='docker-compose'
+      elif groups | grep -Eqw 'sudo|wheel'
+      then
+        DOCKER_COMPOSE_CMD='sudo docker-compose'
       else
         echo >&2 "$SCRIPT_NAME: cannot set docker-compose command: please either"
         echo >&2 "  * add the user '$USER' to the group 'sudo' or 'wheel'"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,7 +5,7 @@ services:
     ports:
       - "5432:5432"
 
-  solr:
+  search:
     ports:
       - "8983:8983"
       


### PR DESCRIPTION
The bash setup scripts were checking if the user was part of the `sudo`/`wheel` groups before checking if they were part of the `docker` group. This resulted in root access being requested when the user is part of the `docker` group where root access would not be required.

Additionally, the code to determine the docker-compose command was looking for the `docker-compose` group which, to my knowledge, doesn't exist (or is non-standard). Checking for the `docker` group should suffice.

Also fixes the docker compose service name in the dev file.