### PR TITLE
Fix FanArtTV URL query separator in provider build_url

### DIFF
--- a/lidarrmetadata/provider.py
+++ b/lidarrmetadata/provider.py
@@ -809,7 +809,7 @@ class FanArtTvProvider(HttpProvider,
         if url[-1] != '/':
             url += '/'
         url += mbid
-        url += '/?api_key={api_key}'.format(api_key=self._api_key)
+        url += '?api_key={api_key}'.format(api_key=self._api_key)
         return url
 
     @staticmethod


### PR DESCRIPTION
## Summary
Fixes one URL construction bug in `FanArtTvProvider.build_url`.

### Change
- Replace `/?api_key=...` with `?api_key=...` so the generated URL is:
  - before: `<base>/<mbid>/?api_key=...`
  - after: `<base>/<mbid>?api_key=...`

## Why
Some upstream endpoints reject the extra slash before the query string, which can break fanart lookups.

## Scope
- One file changed
- One line changed


## Reference
https://github.com/HVR88/Limbo/discussions/2#discussioncomment-16027379